### PR TITLE
add devcontainer config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        git tar build-essential cmake ninja-build \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+  "name": "Raspberry Pi Pico (C/C++) Dev Container",
+  "build": { "dockerfile": "Dockerfile" },
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-vscode.cpptools",
+        "raspberry-pi.raspberry-pi-pico"
+      ],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash"
+      }
+    }
+  },
+
+  "containerEnv": {
+    "PICO_SDK_PATH": "/workspaces/pico-sdk",
+    "PICO_BOARD": "pico"
+  },
+
+  "postCreateCommand": "sudo apt-get update && sudo apt-get install -y gcc-arm-none-eabi libnewlib-arm-none-eabi cmake ninja-build build-essential python3 && if [ ! -d /workspaces/pico-sdk ]; then git clone --recurse-submodules https://github.com/raspberrypi/pico-sdk.git /workspaces/pico-sdk; fi && arm-none-eabi-gcc --version && cmake --version && python3 --version"
+}


### PR DESCRIPTION
Adds initial devcontainer configuration for Codespaces, including Dockerfile and development environment dependencies. Resolves #39 

Note: This PR is self reviewed because it only adds environment setup files and does not affect or modify any source files.